### PR TITLE
Add timezone conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ First of all you need to download your Spotify detailed data from the [Spotify p
 2. Unzip.
 3. Run SpotifyRewrappedGUI.exe
 4. Fill the input path (path where your StreamingHistory.json is located) and the output path (where spotify-rewrapped.png will be generated)
-5. Generate
+5. Optionally, fill out your timezone with quotes (otherwise defaults to UTC). [Wikipedia listed timezones under 'TZ Database Name' column.](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+6. Generate
 
 ## On Linux
 1. You need to clone this repo (or download as ZIP) and run the python code.
@@ -26,9 +27,9 @@ First of all you need to download your Spotify detailed data from the [Spotify p
     ```
 3. Run linux.py
     ```bash
-    python3 ./linux.py <input_path> <output_path>
+    python3 ./linux.py <input_path> <output_path> <timezone>
     ```
     for example:
     ```bash
-    python3 ./linux.py /mnt/d/spotify_data /mnt/d/images
+    python3 ./linux.py /mnt/d/spotify_data /mnt/d/images 'US/Pacific'
     ```

--- a/data_manager.py
+++ b/data_manager.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 class DataManager:
     """It's main responsability is to store the input data and allow querying it"""
-    def __init__(self, files=None):
+    def __init__(self, files=None, timezone='UTC'):
         # Read input files
         self.df = pd.DataFrame()
         for file in files:
@@ -13,7 +13,7 @@ class DataManager:
             self.df = pd.concat([self.df, data_frame], axis=0)
 
         # Filter and process data
-        self.df.endTime = pd.to_datetime(self.df.endTime)
+        self.df.endTime = pd.to_datetime(self.df.endTime).dt.tz_localize('UTC').dt.tz_convert(timezone)
         self.df = self.df[self.df.endTime.dt.year == 2021]
         self.df = self.df[self.df.msPlayed > 10000]
 

--- a/linux.py
+++ b/linux.py
@@ -4,5 +4,6 @@ from spotify_rewrapped import SpotifyRewrapped
 
 input_path = sys.argv[1]
 output_file = sys.argv[2] + '/spotify-rewrapped.png'
+timezone = sys.argv[3] if len(sys.argv) == 4 else 'UTC'
 
-SpotifyRewrapped(path=input_path, output=output_file)
+SpotifyRewrapped(path=input_path, output=output_file, timezone=timezone)

--- a/spotify_rewrapped.py
+++ b/spotify_rewrapped.py
@@ -10,9 +10,10 @@ from image_generator import ImageGenerator
 class SpotifyRewrapped:
     """Spotify Rewrapped. Main class"""
 
-    def __init__(self, path, output):
+    def __init__(self, path, output, timezone='UTC'):
         self.path = path
         self.output = output
+        self.timezone = timezone
         self.generate()
         self.cleanup()
 
@@ -22,7 +23,7 @@ class SpotifyRewrapped:
         pg = PlotGenerator(path=self.path,
                            style='./resources/spotify.mplstyle',
                            font='./resources/gotham-medium.otf')
-        dm = DataManager(glob.glob(f'{self.path}/StreamingHistory[0-9].json'))
+        dm = DataManager(glob.glob(f'{self.path}/StreamingHistory[0-9].json'), timezone=self.timezone)
 
         # Top artists by hours_played
         top = dm.get_top_n_artists(20)


### PR DESCRIPTION
## What?
This PR adds the option of converting Spotify's default time zone of UTC to the user's inputted time zone.

## Why?
I noticed my 'Hours played by time of day' were based in the UTC time zone and not in my correct time zone.

## How?
Simply add the optional time zone argument to the command (e.g. python3 ./linux.py /mnt/d/spotify_data /mnt/d/images 'US/Pacific')
List of time zones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

## Anything Else?
spotify_rewrapped_gui.py may need a little tinkering to ask for and list time zones